### PR TITLE
anonymousCartId field is deprecated use new field anonymousCart

### DIFF
--- a/Task04c_merging.ts
+++ b/Task04c_merging.ts
@@ -19,7 +19,10 @@ const mergingProcessTest = async () => {
     const customerDetails: CustomerSignin = {
         email: "test@test.com",
         password: "password",
-        anonymousCartId: anonymousCart.body.id,
+        anonymousCart: {
+            typeId: "cart",
+            id: anonymousCart.body.id
+        },
         anonymousCartSignInMode: "MergeWithExistingCustomerCart", // try switching to UseAsNewActiveCustomerCart
     };
 


### PR DESCRIPTION
anonymousCartId field is deprecated in SignInDetails. Use the new field anonymousCart.